### PR TITLE
Fix invoices pagination to show 10 per page

### DIFF
--- a/src/components/Dashboard/Invoices.css
+++ b/src/components/Dashboard/Invoices.css
@@ -288,7 +288,14 @@
 
 .pagination {
     display: flex;
+    align-items: center;
     gap: 0.5rem;
+}
+
+.page-info {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    margin: 0 0.5rem;
 }
 
 .pagination-btn {


### PR DESCRIPTION
Implement functional pagination on the invoices page to correctly limit items displayed per page.

---
<a href="https://cursor.com/background-agent?bcId=bc-41453397-8e7d-46c7-9f24-3755ddaddf2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41453397-8e7d-46c7-9f24-3755ddaddf2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

