### PR TITLE
Fix mobile footer display

### DIFF
--- a/src/components/Dashboard/Footer.css
+++ b/src/components/Dashboard/Footer.css
@@ -1,3 +1,4 @@
+/* Dashboard Footer */
 .dashboard-footer {
     padding: 0.75rem 1.5rem;
     background-color: var(--bg-primary);
@@ -228,10 +229,12 @@
         justify-content: center;
     }
 
+    /* Hide link grid on small screens to keep footer compact */
     .footer-links-mobile {
-        grid-template-columns: 1fr;
-        gap: 1.5rem;
-        text-align: center;
+        display: none;
+        margin: 0;
+        padding: 0;
+        border: 0;
     }
 
     .footer-links-column {
@@ -266,8 +269,8 @@
         font-size: 1rem;
     }
 
+    /* Keep links hidden on very small screens as well */
     .footer-links-mobile {
-        gap: 1rem;
-        padding: 1rem 0;
+        display: none;
     }
-} 
+}


### PR DESCRIPTION
Hide large link sections in the mobile footer to prevent it from appearing overly tall.

---
<a href="https://cursor.com/background-agent?bcId=bc-748a0663-331f-4a06-90c5-17931ade1698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-748a0663-331f-4a06-90c5-17931ade1698">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

