### PR TITLE
Fix footer overlapping body content

### DIFF
--- a/src/components/Dashboard/DashboardLayout.css
+++ b/src/components/Dashboard/DashboardLayout.css
@@ -60,12 +60,17 @@
     
     .content-wrapper {
         padding: 1rem;
-        padding-bottom: 2rem; /* Extra padding for mobile footer */
+        padding-bottom: 3rem; /* Increased padding for mobile footer */
     }
 
     /* Ensure footer doesn't overlap with mobile nav */
     .dashboard-footer {
-        margin-bottom: 80px;
+        margin-bottom: 100px; /* Increased margin to create more space */
+    }
+    
+    /* Additional spacing for the last element in content */
+    .content-wrapper > *:last-child {
+        margin-bottom: 2rem; /* Extra space before mobile nav */
     }
 }
 
@@ -77,10 +82,15 @@
     
     .content-wrapper {
         padding: 0.75rem;
-        padding-bottom: 1.5rem;
+        padding-bottom: 2.5rem; /* Increased padding for mobile footer */
     }
 
     .dashboard-footer {
-        margin-bottom: 70px;
+        margin-bottom: 90px; /* Increased margin to create more space */
+    }
+    
+    /* Additional spacing for the last element in content */
+    .content-wrapper > *:last-child {
+        margin-bottom: 1.5rem; /* Extra space before mobile nav */
     }
 } 

--- a/src/components/Dashboard/Footer.css
+++ b/src/components/Dashboard/Footer.css
@@ -64,7 +64,7 @@
 /* Mobile Footer Styles */
 .mobile-footer {
     width: 100%;
-    padding: 1.5rem 0;
+    padding: 1.5rem 0 2rem 0; /* Increased bottom padding */
 }
 
 .mobile-footer-section {
@@ -158,6 +158,7 @@
 .footer-bottom-mobile {
     text-align: center;
     padding-top: 1rem;
+    padding-bottom: 1rem; /* Added bottom padding for extra spacing */
 }
 
 .copyright-mobile {

--- a/src/components/MobileNav/MobileNav.css
+++ b/src/components/MobileNav/MobileNav.css
@@ -6,7 +6,7 @@
   background: var(--bg-primary);
   border-top: 1px solid var(--border-color);
   z-index: 1000;
-  padding: 0.5rem 0;
+  padding: 0.75rem 0; /* Increased padding for better spacing */
   box-shadow: 0 -4px 6px -1px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
@@ -103,7 +103,7 @@
 /* Responsive adjustments */
 @media (max-width: 480px) {
   .mobile-nav {
-    padding: 0.375rem 0;
+    padding: 0.5rem 0; /* Increased padding for better spacing */
   }
 
   .mobile-nav-container {


### PR DESCRIPTION
Adjust spacing to prevent the footer from overlapping with body content on mobile.

The footer content (copyright text) was positioned too close to the mobile navigation bar, creating a cramped appearance. This PR increases padding and margins in `DashboardLayout.css`, `Footer.css`, and `MobileNav.css` to ensure proper visual separation between the main content and the fixed mobile navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-b571ff56-da3a-49fa-ac33-ac628752e57b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b571ff56-da3a-49fa-ac33-ac628752e57b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

